### PR TITLE
Skip logging stack trace for ApplicationExceptions with BAD_GATEWAY status.

### DIFF
--- a/src/main/java/com/iotiq/commons/config/ExceptionHandlerAdvice.java
+++ b/src/main/java/com/iotiq/commons/config/ExceptionHandlerAdvice.java
@@ -40,11 +40,14 @@ public class ExceptionHandlerAdvice extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(ApplicationException.class)
     public ResponseEntity<Object> handleApplicationException(ApplicationException exception, @NonNull WebRequest request) {
-        logException(request, exception);
+        HttpStatusCode status = exception.getStatus();
+
+        if (!HttpStatus.BAD_GATEWAY.equals(status)) {
+            logException(request, exception);
+        }
 
         String defaultDetail = messageSource.getMessage(exception, getLocale());
         String messageCode = ErrorResponse.getDefaultDetailMessageCode(ApplicationException.class, null);
-        HttpStatusCode status = exception.getStatus();
         Object[] arguments = exception.getArguments();
 
         ProblemDetail problemDetail = this.createProblemDetail(exception, status, defaultDetail, messageCode, arguments, request);

--- a/src/main/java/com/iotiq/commons/exceptions/ExternalServiceException.java
+++ b/src/main/java/com/iotiq/commons/exceptions/ExternalServiceException.java
@@ -1,0 +1,21 @@
+package com.iotiq.commons.exceptions;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class ExternalServiceException extends ApplicationException {
+    private String detailMessage;
+    public ExternalServiceException(String message, Object... args) {
+        super(HttpStatus.BAD_GATEWAY, message, args);
+    }
+
+    public ExternalServiceException(String message, String detailMessage, Object... args) {
+        super(HttpStatus.BAD_GATEWAY, message, args);
+        this.detailMessage = detailMessage;
+    }
+
+    public ExternalServiceException(String message) {
+        super(HttpStatus.BAD_GATEWAY, message);
+    }
+}

--- a/src/main/java/com/iotiq/commons/util/LoggingUtils.java
+++ b/src/main/java/com/iotiq/commons/util/LoggingUtils.java
@@ -22,6 +22,10 @@ public class LoggingUtils {
         log.error(getTracedString(var1), var2);
     }
 
+    public static void error(String var1) {
+        log.error(getTracedString(var1));
+    }
+
     private static String getTracedString(String str) {
         String traceId = getOrCreateRequestId();
         return '-' + traceId + "- " + str;


### PR DESCRIPTION
This PR is related to PR https://github.com/Iotiq-Erste/culturati-application/pull/696

- Updated ExceptionHandlerAdvice to suppress log output for known BAD_GATEWAY errors
- Keeps logs clean by avoiding stack traces for expected downstream failure cases